### PR TITLE
Remove .NET 9 target frameworks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/Recyclable.Collections.Benchmarks/bin/Debug/net6.0/Recyclable.Collections.Benchmarks.dll",
+            "program": "${workspaceFolder}/Recyclable.Collections.Benchmarks/bin/Debug/net8.0/Recyclable.Collections.Benchmarks.dll",
             "args": [],
             "cwd": "${workspaceFolder}/Recyclable.Collections.Benchmarks",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console

--- a/Recyclable.Collections.Benchmarks/Recyclable.Collections.Benchmarks.csproj
+++ b/Recyclable.Collections.Benchmarks/Recyclable.Collections.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-                <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+                <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<Platforms>AnyCPU;x64</Platforms>

--- a/Recyclable.Collections/Recyclable.Collections.csproj
+++ b/Recyclable.Collections/Recyclable.Collections.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-                <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+                <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/Recyclable.CollectionsTests/Recyclable.CollectionsTests.csproj
+++ b/Recyclable.CollectionsTests/Recyclable.CollectionsTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/SourceCodeGenerator.Net/SourceCodeGenerator.Net.csproj
+++ b/SourceCodeGenerator.Net/SourceCodeGenerator.Net.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
 	<EnforceExtendedAnalyzerRules>True</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- limit all projects to target .NET 6–8 (defaulting to 8)

## Testing
- `dotnet test Recyclable.Collections.sln -c Debug -f net8.0 --logger "console;verbosity=minimal"`

------
https://chatgpt.com/codex/tasks/task_e_686f93b980008325a0a866eb623931c6