### PR TITLE
Add NuGet package links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS
+
+This repository hosts various libraries distributed as NuGet packages. Keep these links up to date so contributors and tools can easily locate them.
+
+## NuGet packages
+- [Recyclable.Collections](https://github.com/mlemanczyk/Recyclable.Collections)
+- [Recyclable.Collections.Compatibility.List](https://github.com/mlemanczyk/Recyclable.Collections.Compatibility.List)
+- [Recyclable.Collections.Concurrent](https://github.com/mlemanczyk/Recyclable.Collections.Concurrent)
+- [Recyclable.Collections.Linq](https://github.com/mlemanczyk/Recyclable.Collections.Linq)
+- [Recyclable.Collections.Searching](https://github.com/mlemanczyk/Recyclable.Collections.Searching)
+- [Recyclable.Collections.TestData](https://github.com/mlemanczyk/Recyclable.Collections.TestData)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 * `RecyclableList<T>`
 * `RecyclableLongList<T>`
 
+## NuGet packages
+- [Recyclable.Collections](https://github.com/mlemanczyk/Recyclable.Collections)
+- [Recyclable.Collections.Compatibility.List](https://github.com/mlemanczyk/Recyclable.Collections.Compatibility.List)
+- [Recyclable.Collections.Concurrent](https://github.com/mlemanczyk/Recyclable.Collections.Concurrent)
+- [Recyclable.Collections.Linq](https://github.com/mlemanczyk/Recyclable.Collections.Linq)
+- [Recyclable.Collections.Searching](https://github.com/mlemanczyk/Recyclable.Collections.Searching)
+- [Recyclable.Collections.TestData](https://github.com/mlemanczyk/Recyclable.Collections.TestData)
+
 # Milestones
 1. ✅ Create basic classes
 	1. ✅ `RecyclableList<T>`


### PR DESCRIPTION
## Summary
- add a new AGENTS.md with NuGet package links
- document packages in README

## Testing
- `dotnet test -v minimal Recyclable.CollectionsTests/Recyclable.CollectionsTests.csproj --no-build` *(fails: missing .NET frameworks)*

------
https://chatgpt.com/codex/tasks/task_e_686f9fec5d188325854465651af21b1c