### PR TITLE
Polish chunk API docs and style

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,13 @@
 
 This repository hosts various libraries distributed as NuGet packages. Keep these links up to date so contributors and tools can easily locate them.
 
+Only the .NET SDK **8.0** is available in the execution environment. Use this version when building or running tests.
+
+All `*.csproj` files should enable nullable reference types with `<Nullable>enable</Nullable>`.
+Indent code using four spaces or a single tab per level. Place one blank line after each closing curly brace of a code block, except when several closing braces appear sequentially. Always use braces for `if` and `else` bodies.
+All tests must use **xUnit** together with **FluentAssertions**.
+Implementations should be optimized for maximum performance even if that introduces some code duplication. Consider applying attributes such as `MethodImplOptions.AggressiveInlining` or faster alternatives to common operations when appropriate.
+
 ## NuGet packages
 - [Recyclable.Collections](https://github.com/mlemanczyk/Recyclable.Collections)
 - [Recyclable.Collections.Compatibility.List](https://github.com/mlemanczyk/Recyclable.Collections.Compatibility.List)

--- a/Recyclable.Collections/Pools/RecyclableArrayPoolChunk.cs
+++ b/Recyclable.Collections/Pools/RecyclableArrayPoolChunk.cs
@@ -1,0 +1,19 @@
+namespace Recyclable.Collections.Pools
+{
+    public sealed class RecyclableArrayPoolChunk<T>
+    {
+        private static readonly T[] _empty = Array.Empty<T>();
+
+        internal static T[] Empty => _empty;
+
+        internal T[] Buffer;
+        internal int Index;
+        internal RecyclableArrayPoolChunk<T>? Previous;
+        internal RecyclableArrayPoolChunk<T>? Next;
+
+        public RecyclableArrayPoolChunk()
+        {
+            Buffer = _empty;
+        }
+    }
+}

--- a/Recyclable.Collections/Pools/RecyclableArrayPoolChunkPool.cs
+++ b/Recyclable.Collections/Pools/RecyclableArrayPoolChunkPool.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.ObjectPool;
+
+namespace Recyclable.Collections.Pools
+{
+    public static class RecyclableArrayPoolChunkPool<T>
+    {
+        private static readonly ObjectPool<RecyclableArrayPoolChunk<T>> _pool =
+            new DefaultObjectPool<RecyclableArrayPoolChunk<T>>(new DefaultPooledObjectPolicy<RecyclableArrayPoolChunk<T>>());
+
+        public static RecyclableArrayPoolChunk<T> Rent() => _pool.Get();
+
+        public static void Return(RecyclableArrayPoolChunk<T> chunk)
+        {
+            chunk.Index = 0;
+            chunk.Previous = null;
+            chunk.Next = null;
+            _pool.Return(chunk);
+        }
+
+        public static void Dispose(RecyclableArrayPoolChunk<T> chunk, bool needsClearing)
+        {
+            var buffer = chunk.Buffer;
+            if (buffer.Length >= RecyclableDefaults.MinPooledArrayLength)
+            {
+                RecyclableArrayPool<T>.ReturnShared(buffer, needsClearing);
+            }
+            chunk.Buffer = RecyclableArrayPoolChunk<T>.Empty;
+            chunk.Index = 0;
+            chunk.Previous = null;
+            chunk.Next = null;
+            _pool.Return(chunk);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- document spacing, brace, and tab conventions in AGENTS
- make `RecyclableArrayPoolChunk` and `RecyclableArrayPoolChunkPool` public
- enforce 4-space indentation on new chunk classes

## Testing
- `dotnet test -v minimal` *(fails: missing .NET 6.0/7.0 frameworks)*

------
https://chatgpt.com/codex/tasks/task_e_6873f432657883259ff9288fe0ab8ba3