### PR TITLE
Add dataset coverage and fix stack pop test

### DIFF
--- a/Recyclable.CollectionsTests/RecyclableHashSetTests.cs
+++ b/Recyclable.CollectionsTests/RecyclableHashSetTests.cs
@@ -7,49 +7,74 @@ namespace Recyclable.CollectionsTests
 {
     public class RecyclableHashSetTests
     {
-        [Fact]
-        public void AddShouldStoreUniqueItems()
+        [Theory]
+        [MemberData(nameof(RecyclableLongListTestData.ItemsCountTestCases), MemberType = typeof(RecyclableLongListTestData))]
+        public void AddShouldStoreUniqueItems(int itemsCount)
         {
-            using var set = new RecyclableHashSet<string>();
-            set.Add("a").Should().BeTrue();
-            set.Add("b").Should().BeTrue();
-            set.Add("a").Should().BeFalse();
-
-            _ = set.Should().HaveCount(2);
-            _ = set.Contains("a").Should().BeTrue();
-            _ = set.Contains("b").Should().BeTrue();
-        }
-
-        [Fact]
-        public void RemoveShouldDeleteItem()
-        {
-            using var set = new RecyclableHashSet<int>();
-            set.Add(1);
-            set.Add(2);
-
-            set.Remove(1).Should().BeTrue();
-
-            _ = set.Contains(1).Should().BeFalse();
-            _ = set.Should().HaveCount(1);
-        }
-
-        [Fact]
-        public void EnumeratorShouldYieldItems()
-        {
-            using var set = new RecyclableHashSet<int>();
-            for (int i = 0; i < 5; i++)
+            using var set = new RecyclableHashSet<long>();
+            foreach (var item in RecyclableLongListTestData.CreateTestData(itemsCount))
             {
-                set.Add(i);
+                set.Add(item).Should().BeTrue();
             }
 
-            var actual = new List<int>();
+            foreach (var item in RecyclableLongListTestData.CreateTestData(itemsCount))
+            {
+                set.Add(item).Should().BeFalse();
+            }
+
+            _ = set.Should().HaveCount(itemsCount);
+        }
+
+        [Theory]
+        [MemberData(nameof(RecyclableLongListTestData.ItemsCountTestCases), MemberType = typeof(RecyclableLongListTestData))]
+        public void RemoveShouldDeleteItem(int itemsCount)
+        {
+            using var set = new RecyclableHashSet<long>();
+            foreach (var item in RecyclableLongListTestData.CreateTestData(itemsCount))
+            {
+                set.Add(item);
+            }
+
+            if (itemsCount > 0)
+            {
+                long value = (itemsCount + 1) / 2;
+                set.Remove(value).Should().BeTrue();
+                _ = set.Contains(value).Should().BeFalse();
+                _ = set.Should().HaveCount(itemsCount - 1);
+            }
+            else
+            {
+                set.Remove(0).Should().BeFalse();
+                _ = set.Should().BeEmpty();
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(RecyclableLongListTestData.ItemsCountTestCases), MemberType = typeof(RecyclableLongListTestData))]
+        public void EnumeratorShouldYieldItems(int itemsCount)
+        {
+            using var set = new RecyclableHashSet<long>();
+            foreach (var item in RecyclableLongListTestData.CreateTestData(itemsCount))
+            {
+                set.Add(item);
+            }
+
+            var actual = new List<long>();
             var enumerator = set.GetEnumerator();
             while (enumerator.MoveNext())
             {
                 actual.Add(enumerator.Current);
             }
 
-            _ = actual.Should().Contain(Enumerable.Range(0, 5)).And.HaveCount(5);
+            var expected = RecyclableLongListTestData.CreateTestData(itemsCount).ToList();
+            if (itemsCount == 0)
+            {
+                _ = actual.Should().BeEmpty();
+            }
+            else
+            {
+                _ = actual.Should().Contain(expected).And.HaveCount(itemsCount);
+            }
         }
     }
 }

--- a/Recyclable.CollectionsTests/RecyclableLinkedListTests.cs
+++ b/Recyclable.CollectionsTests/RecyclableLinkedListTests.cs
@@ -8,36 +8,40 @@ namespace Recyclable.CollectionsTests
     {
         private static readonly string[] _testData = new[] { "a", "d", "c", "b", "a" };
 
-        [Fact]
-        public void AddLastShouldPreserveOrder()
+        [Theory]
+        [MemberData(nameof(RecyclableLongListTestData.ItemsCountTestCases), MemberType = typeof(RecyclableLongListTestData))]
+        public void AddLastShouldPreserveOrder(int itemsCount)
         {
-            using var list = new RecyclableLinkedList<string>();
-            foreach (var item in _testData)
+            using var list = new RecyclableLinkedList<long>();
+            var expected = RecyclableLongListTestData.CreateTestData(itemsCount).ToArray();
+            foreach (var item in expected)
             {
                 list.AddLast(item);
             }
 
-            var actual = new RecyclableLongList<string>();
+            var actual = new RecyclableLongList<long>();
             foreach (var item in list)
             {
                 actual.Add(item);
             }
 
-            _ = actual.Should().ContainInConsecutiveOrder(_testData)
-                .And.BeEquivalentTo(_testData);
+            _ = actual.Should().ContainInConsecutiveOrder(expected)
+                .And.BeEquivalentTo(expected);
         }
 
-        [Fact]
-        public void AddFirstShouldReverseOrder()
+        [Theory]
+        [MemberData(nameof(RecyclableLongListTestData.ItemsCountTestCases), MemberType = typeof(RecyclableLongListTestData))]
+        public void AddFirstShouldReverseOrder(int itemsCount)
         {
-            using var list = new RecyclableLinkedList<string>();
-            foreach (var item in _testData)
+            using var list = new RecyclableLinkedList<long>();
+            var source = RecyclableLongListTestData.CreateTestData(itemsCount).ToArray();
+            foreach (var item in source)
             {
                 list.AddFirst(item);
             }
 
-            var expected = _testData.Reverse().ToArray();
-            var actual = new RecyclableLongList<string>();
+            var expected = source.Reverse().ToArray();
+            var actual = new RecyclableLongList<long>();
             foreach (var item in list)
             {
                 actual.Add(item);
@@ -46,30 +50,34 @@ namespace Recyclable.CollectionsTests
             _ = actual.Should().ContainInConsecutiveOrder(expected);
         }
 
-        [Fact]
-        public void RemoveFirstShouldReturnItemsInOrder()
+        [Theory]
+        [MemberData(nameof(RecyclableLongListTestData.ItemsCountTestCases), MemberType = typeof(RecyclableLongListTestData))]
+        public void RemoveFirstShouldReturnItemsInOrder(int itemsCount)
         {
-            using var list = new RecyclableLinkedList<string>(_testData);
-            var actual = new RecyclableLongList<string>();
+            var source = RecyclableLongListTestData.CreateTestData(itemsCount).ToArray();
+            using var list = new RecyclableLinkedList<long>(source);
+            var actual = new RecyclableLongList<long>();
             while (list.LongCount > 0)
             {
                 actual.Add(list.RemoveFirst());
             }
 
-            _ = actual.Should().ContainInConsecutiveOrder(_testData);
+            _ = actual.Should().ContainInConsecutiveOrder(source);
         }
 
-        [Fact]
-        public void RemoveLastShouldReturnItemsInReverseOrder()
+        [Theory]
+        [MemberData(nameof(RecyclableLongListTestData.ItemsCountTestCases), MemberType = typeof(RecyclableLongListTestData))]
+        public void RemoveLastShouldReturnItemsInReverseOrder(int itemsCount)
         {
-            using var list = new RecyclableLinkedList<string>(_testData);
-            var actual = new RecyclableLongList<string>();
+            var source = RecyclableLongListTestData.CreateTestData(itemsCount).ToArray();
+            using var list = new RecyclableLinkedList<long>(source);
+            var actual = new RecyclableLongList<long>();
             while (list.LongCount > 0)
             {
                 actual.Add(list.RemoveLast());
             }
 
-            _ = actual.Should().ContainInConsecutiveOrder(_testData.Reverse());
+            _ = actual.Should().ContainInConsecutiveOrder(source.Reverse());
         }
     }
 }

--- a/Recyclable.CollectionsTests/RecyclableQueueTests.cs
+++ b/Recyclable.CollectionsTests/RecyclableQueueTests.cs
@@ -7,117 +7,134 @@ namespace Recyclable.CollectionsTests
 	{
 		private static readonly string[] _testData = new[] { "a", "d", "c", "b", "a" };
 
-		[Fact]
-		public void ShouldNotBeSortedWhenCreated()
-		{
-			// Act
-			using var list = new RecyclableQueue<string>(_testData, 2);
+                [Theory]
+                [MemberData(nameof(RecyclableLongListTestData.ItemsCountTestCases), MemberType = typeof(RecyclableLongListTestData))]
+                public void ShouldNotBeSortedWhenCreated(int itemsCount)
+                {
+                        // Act
+                        var data = RecyclableLongListTestData.CreateTestData(itemsCount).Select(i => i.ToString()).ToArray();
+                        using var list = new RecyclableQueue<string>(data, 2);
 
-			// Validate
-			_ = list.Should().HaveCount(_testData.Length)
-				.And.ContainInConsecutiveOrder(_testData);
-			_ = list.LongCount.Should().Be(_testData.Length);
-		}
+                        // Validate
+                        _ = list.Should().HaveCount(itemsCount)
+                                .And.ContainInConsecutiveOrder(data);
+                        _ = list.LongCount.Should().Be(itemsCount);
+                }
 
-		[Fact]
-		public void ShouldBeEmptyWhenNotInitialized()
-		{
-			// Act
-			using var list = new RecyclableQueue<string>(2);
+                [Fact]
+                public void ShouldBeEmptyWhenNotInitialized()
+                {
+                        // Act
+                        using var list = new RecyclableQueue<string>(2);
 
-			// Validate
-			_ = list.Should().BeEmpty();
-			_ = list.LongCount.Should().Be(0);
-		}
+                        // Validate
+                        _ = list.Should().BeEmpty();
+                        _ = list.LongCount.Should().Be(0);
+                }
 
-		[Fact]
-		public void ShouldNotBeSortedWhenInitialized()
-		{
-			// Act
-			using var list = new RecyclableQueue<string>(2)
-			{
-				_testData[0],
-				_testData[1],
-				_testData[2],
-				_testData[3],
-				_testData[4]
-			};
+                [Theory]
+                [MemberData(nameof(RecyclableLongListTestData.ItemsCountTestCases), MemberType = typeof(RecyclableLongListTestData))]
+                public void ShouldNotBeSortedWhenInitialized(int itemsCount)
+                {
+                        // Act
+                        var data = RecyclableLongListTestData.CreateTestData(itemsCount).Select(i => i.ToString()).ToArray();
+                        using var list = new RecyclableQueue<string>(2)
+                        {
+                                // populate via collection initializer
+                        };
+                        foreach (var item in data)
+                        {
+                                list.Enqueue(item);
+                        }
 
-			// Validate
-			_ = list.Should().NotBeEmpty()
-				.And.ContainInConsecutiveOrder(_testData)
-				.And.BeEquivalentTo(_testData);
-		}
+                        // Validate
+                        if (itemsCount == 0)
+                        {
+                                _ = list.Should().BeEmpty();
+                        }
+                        else
+                        {
+                                _ = list.Should().NotBeEmpty()
+                                        .And.ContainInConsecutiveOrder(data)
+                                        .And.BeEquivalentTo(data);
+                        }
+                }
 
-		[Fact]
-		public void ShouldBeEmptyAfterClear()
-		{
-			// Prepare
-			using var list = new RecyclableQueue<string>(_testData);
+                [Theory]
+                [MemberData(nameof(RecyclableLongListTestData.ItemsCountTestCases), MemberType = typeof(RecyclableLongListTestData))]
+                public void ShouldBeEmptyAfterClear(int itemsCount)
+                {
+                        // Prepare
+                        var data = RecyclableLongListTestData.CreateTestData(itemsCount).Select(i => i.ToString());
+                        using var list = new RecyclableQueue<string>(data);
 
-			// Act
-			list.Clear();
+                        // Act
+                        list.Clear();
 
-			// Validate
-			_ = list.Should().BeEmpty();
-		}
+                        // Validate
+                        _ = list.Should().BeEmpty();
+                }
 
-		[Fact]
-		public void DequeueShouldReturnItemsInTheSameOrder()
-		{
-			// Prepare
-			using var list = new RecyclableQueue<string>();
+                [Theory]
+                [MemberData(nameof(RecyclableLongListTestData.ItemsCountTestCases), MemberType = typeof(RecyclableLongListTestData))]
+                public void DequeueShouldReturnItemsInTheSameOrder(int itemsCount)
+                {
+                        // Prepare
+                        var data = RecyclableLongListTestData.CreateTestData(itemsCount).Select(i => i.ToString()).ToArray();
+                        using var list = new RecyclableQueue<string>();
 
-			// Act
-			for (var itemIdx = 0; itemIdx < _testData.Length; itemIdx++)
-			{
-				list.Enqueue(_testData[itemIdx]);
-			}
+                        // Act
+                        for (var itemIdx = 0; itemIdx < data.Length; itemIdx++)
+                        {
+                                list.Enqueue(data[itemIdx]);
+                        }
 
-			var dequeuedItems = new RecyclableLongList<string>();
-			while (list.LongCount > 0)
-			{
-				dequeuedItems.Add(list.Dequeue());
-			}
+                        var dequeuedItems = new RecyclableLongList<string>();
+                        while (list.LongCount > 0)
+                        {
+                                dequeuedItems.Add(list.Dequeue());
+                        }
 
-			// Validate
-			_ = dequeuedItems.Should().ContainInConsecutiveOrder(_testData)
-				.And.BeEquivalentTo(_testData);
-		}
+                        // Validate
+                        _ = dequeuedItems.Should().ContainInConsecutiveOrder(data)
+                                .And.BeEquivalentTo(data);
+                }
 
-		[Fact]
-		public void DequeueShoudRaiseArgumentOutOfRangeWhenNoMoreElementsFound()
-		{
-			// Prepare
-			using var list = new RecyclableQueue<string>(_testData);
+                [Fact]
+                public void DequeueShoudRaiseArgumentOutOfRangeWhenNoMoreElementsFound()
+                {
+                        // Prepare
+                        using var list = new RecyclableQueue<string>(_testData);
 
-			// Act
-			while (list.LongCount > 0)
-			{
-				_ = list.Dequeue();
-			}
+                        // Act
+                        while (list.LongCount > 0)
+                        {
+                                _ = list.Dequeue();
+                        }
 
-			_ = Assert.Throws<ArgumentOutOfRangeException>(() => list.Dequeue());
-			_ = list.LongCount.Should().Be(0);
-		}
+                        _ = Assert.Throws<ArgumentOutOfRangeException>(() => list.Dequeue());
+                        _ = list.LongCount.Should().Be(0);
+                }
 
-		[Fact]
-		public void GetEnumeratorShouldYieldAllItemsInTheSameOrder()
-		{
-			// Prepare
-			using var list = new RecyclableQueue<string>(_testData);
+                [Theory]
+                [MemberData(nameof(RecyclableLongListTestData.ItemsCountTestCases), MemberType = typeof(RecyclableLongListTestData))]
+                public void GetEnumeratorShouldYieldAllItemsInTheSameOrder(int itemsCount)
+                {
+                        // Prepare
+                        var data = RecyclableLongListTestData.CreateTestData(itemsCount).Select(i => i.ToString()).ToArray();
+                        using var list = new RecyclableQueue<string>(data);
 
-			// Act
-			var actual = new RecyclableLongList<string>();
-			using var enumerator = list.GetEnumerator();
-			while (enumerator.MoveNext())
-			{
-				actual.Add(enumerator.Current);
-			}
+                        // Act
+                        var actual = new RecyclableLongList<string>();
+                        using var enumerator = list.GetEnumerator();
+                        while (enumerator.MoveNext())
+                        {
+                                actual.Add(enumerator.Current);
+                        }
 
-			// Validate
-			_ = actual.Should().ContainInConsecutiveOrder(_testData)
-				.And.BeEquivalentTo(_testData);
-		}
+                        // Validate
+                        _ = actual.Should().ContainInConsecutiveOrder(data)
+                                .And.BeEquivalentTo(data);
+                }
 	}
 }

--- a/Recyclable.CollectionsTests/RecyclableSortedListTests.cs
+++ b/Recyclable.CollectionsTests/RecyclableSortedListTests.cs
@@ -7,17 +7,20 @@ namespace Recyclable.CollectionsTests
 	{
 		private static readonly (int, string)[] _testData = new[] { (5, "a"), (4, "d"), (3, "c"), (2, "b"), (1, "a") };
 
-		[Fact]
-		public void ShouldBeSortedWhenCreated()
-		{
-			// Act
-			using var sortedList = new RecyclableSortedList<int, string>(_testData, 2);
+                [Theory]
+                [MemberData(nameof(RecyclableLongListTestData.ItemsCountTestCases), MemberType = typeof(RecyclableLongListTestData))]
+                public void ShouldBeSortedWhenCreated(int itemsCount)
+                {
+                        // Act
+                        var data = RecyclableLongListTestData.CreateTestData(itemsCount)
+                                .Select(x => (itemsCount - x + 1, x))
+                                .ToArray();
+                        using var sortedList = new RecyclableSortedList<long, long>(data, 2);
 
-			// Validate
-			_ = sortedList.Should().HaveCount(_testData.Length)
-				.And.BeEquivalentTo(_testData)
-				.And.BeInAscendingOrder((item) => item.Key);
-		}
+                        // Validate
+                        _ = sortedList.Should().HaveCount(itemsCount)
+                                .And.BeInAscendingOrder(item => item.Key);
+                }
 
 		[Fact]
 		public void ShouldBeEmptyWhenNotInitialized()
@@ -47,40 +50,44 @@ namespace Recyclable.CollectionsTests
 				.And.ContainInConsecutiveOrder(_testData);
 		}
 
-		[Fact]
-		public void ShouldBeSortedWhenUpdateEnds()
-		{
-			// Prepare
-			using var sortedList = new RecyclableSortedList<int, string>(2);
+                [Theory]
+                [MemberData(nameof(RecyclableLongListTestData.ItemsCountTestCases), MemberType = typeof(RecyclableLongListTestData))]
+                public void ShouldBeSortedWhenUpdateEnds(int itemsCount)
+                {
+                        // Prepare
+                        using var sortedList = new RecyclableSortedList<long, long>(2);
 
-			// Act
-			sortedList.BeginUpdate();
-			foreach (var testItem in _testData)
-			{
-				sortedList.Add(testItem);
-			}
+                        // Act
+                        sortedList.BeginUpdate();
+                        foreach (var value in RecyclableLongListTestData.CreateTestData(itemsCount))
+                        {
+                                sortedList.Add((itemsCount - value + 1, value));
+                        }
 
-			// Validate
-			_ = sortedList.Should().BeInDescendingOrder(x => x.Key);
+                        // Validate
+                        _ = sortedList.Should().BeInDescendingOrder(x => x.Key);
 
-			// Act
-			sortedList.EndUpdate();
+                        // Act
+                        sortedList.EndUpdate();
 
-			// Validate
-			_ = sortedList.Should().BeInAscendingOrder(x => x.Key);
-		}
+                        // Validate
+                        _ = sortedList.Should().BeInAscendingOrder(x => x.Key);
+                }
 
-		[Fact]
-		public void ShouldBeEmptyAfterClear()
-		{
-			// Prepare
-			using var sortedList = new RecyclableSortedList<int, string>(_testData);
+                [Theory]
+                [MemberData(nameof(RecyclableLongListTestData.ItemsCountTestCases), MemberType = typeof(RecyclableLongListTestData))]
+                public void ShouldBeEmptyAfterClear(int itemsCount)
+                {
+                        // Prepare
+                        var data = RecyclableLongListTestData.CreateTestData(itemsCount)
+                                .Select(x => (x, x));
+                        using var sortedList = new RecyclableSortedList<long, long>(data);
 
-			// Act
-			sortedList.Clear();
+                        // Act
+                        sortedList.Clear();
 
-			// Validate
-			_ = sortedList.Should().BeEmpty();
-		}
-	}
+                        // Validate
+                        _ = sortedList.Should().BeEmpty();
+                }
+        }
 }

--- a/Recyclable.CollectionsTests/RecyclableStackTests.cs
+++ b/Recyclable.CollectionsTests/RecyclableStackTests.cs
@@ -7,112 +7,126 @@ namespace Recyclable.CollectionsTests
 	{
 		private static readonly string[] _testData = new[] { "a", "d", "c", "b", "a" };
 
-		[Fact]
-		public void GetEnumeratorShouldYieldAllItemsInReversedOrder()
-		{
-			// Prepare
-			using var list = new RecyclableStack<string>(_testData);
+                [Theory]
+                [MemberData(nameof(RecyclableLongListTestData.ItemsCountTestCases), MemberType = typeof(RecyclableLongListTestData))]
+                public void GetEnumeratorShouldYieldAllItemsInReversedOrder(int itemsCount)
+                {
+                        // Prepare
+                        var data = RecyclableLongListTestData.CreateTestData(itemsCount).Select(i => i.ToString()).ToArray();
+                        using var list = new RecyclableStack<string>(data);
 
-			// Act
-			var actual = new RecyclableLongList<string>();
-			using var enumerator = list.GetEnumerator();
-			while (enumerator.MoveNext())
-			{
-				actual.Add(enumerator.Current);
-			}
+                        // Act
+                        var actual = new RecyclableLongList<string>();
+                        using var enumerator = list.GetEnumerator();
+                        while (enumerator.MoveNext())
+                        {
+                                actual.Add(enumerator.Current);
+                        }
 
-			// Validate
-			_ = actual.Should().ContainInConsecutiveOrder(_testData.Reverse());
-		}
+                        // Validate
+                        _ = actual.Should().ContainInConsecutiveOrder(data.Reverse());
+                }
 
-		[Fact]
-		public void ShouldNotBeSortedWhenCreated()
-		{
-			// Act
-			using var sortedList = new RecyclableStack<string>(_testData, 2);
+                [Theory]
+                [MemberData(nameof(RecyclableLongListTestData.ItemsCountTestCases), MemberType = typeof(RecyclableLongListTestData))]
+                public void ShouldNotBeSortedWhenCreated(int itemsCount)
+                {
+                        // Act
+                        var data = RecyclableLongListTestData.CreateTestData(itemsCount).Select(i => i.ToString()).ToArray();
+                        using var sortedList = new RecyclableStack<string>(data, 2);
 
-			// Validate
-                        _ = sortedList.Should().HaveCount(_testData.Length)
-                                .And.ContainInConsecutiveOrder(_testData.Reverse());
-		}
+                        // Validate
+                        _ = sortedList.Should().HaveCount(itemsCount)
+                                .And.ContainInConsecutiveOrder(data.Reverse());
+                }
 
-		[Fact]
-		public void ShouldBeEmptyWhenNotInitialized()
-		{
-			// Act
-			using var sortedList = new RecyclableStack<string>(2);
+                [Fact]
+                public void ShouldBeEmptyWhenNotInitialized()
+                {
+                        // Act
+                        using var sortedList = new RecyclableStack<string>(2);
 
-			// Validate
-			_ = sortedList.Should().BeEmpty();
-		}
+                        // Validate
+                        _ = sortedList.Should().BeEmpty();
+                }
 
-		[Fact]
-		public void ShouldNotBeSortedWhenInitialized()
-		{
-			// Act
-			using var sortedList = new RecyclableStack<string>(2)
-			{
-				_testData[0],
-				_testData[1],
-				_testData[2],
-				_testData[3],
-				_testData[4]
-			};
+                [Theory]
+                [MemberData(nameof(RecyclableLongListTestData.ItemsCountTestCases), MemberType = typeof(RecyclableLongListTestData))]
+                public void ShouldNotBeSortedWhenInitialized(int itemsCount)
+                {
+                        // Act
+                        var data = RecyclableLongListTestData.CreateTestData(itemsCount).Select(i => i.ToString()).ToArray();
+                        using var sortedList = new RecyclableStack<string>(2);
+                        foreach (var item in data)
+                        {
+                                sortedList.Push(item);
+                        }
 
-			// Validate
-                        _ = sortedList.Should().NotBeEmpty()
-                                .And.ContainInConsecutiveOrder(_testData.Reverse())
-                                .And.BeEquivalentTo(_testData);
-		}
+                        // Validate
+                        if (itemsCount == 0)
+                        {
+                                _ = sortedList.Should().BeEmpty();
+                        }
+                        else
+                        {
+                                _ = sortedList.Should().NotBeEmpty()
+                                        .And.ContainInConsecutiveOrder(data.Reverse())
+                                        .And.BeEquivalentTo(data);
+                        }
+                }
 
-		[Fact]
-		public void ShouldBeEmptyAfterClear()
-		{
-			// Prepare
-			using var sortedList = new RecyclableStack<string>(_testData);
+                [Theory]
+                [MemberData(nameof(RecyclableLongListTestData.ItemsCountTestCases), MemberType = typeof(RecyclableLongListTestData))]
+                public void ShouldBeEmptyAfterClear(int itemsCount)
+                {
+                        // Prepare
+                        var data = RecyclableLongListTestData.CreateTestData(itemsCount).Select(i => i.ToString()).ToArray();
+                        using var sortedList = new RecyclableStack<string>(data);
 
-			// Act
-			sortedList.Clear();
+                        // Act
+                        sortedList.Clear();
 
-			// Validate
-			_ = sortedList.Should().BeEmpty();
-		}
+                        // Validate
+                        _ = sortedList.Should().BeEmpty();
+                }
 
-		[Fact]
-		public void PopShouldReturnItemsInReversedOrder()
-		{
-			// Prepare
-			using var list = new RecyclableStack<string>();
+                [Theory]
+                [MemberData(nameof(RecyclableLongListTestData.ItemsCountTestCases), MemberType = typeof(RecyclableLongListTestData))]
+                public void PopShouldReturnItemsInReversedOrder(int itemsCount)
+                {
+                        // Prepare
+                        using var list = new RecyclableStack<string>();
 
-			// Act
-			for (var itemIdx = 0; itemIdx < _testData.Length; itemIdx++)
-			{
-				list.Push(_testData[itemIdx]);
-			}
+                        // Act
+                        var data = RecyclableLongListTestData.CreateTestData(itemsCount).Select(i => i.ToString()).ToArray();
+                        for (var itemIdx = 0; itemIdx < data.Length; itemIdx++)
+                        {
+                                list.Push(data[itemIdx]);
+                        }
 
-			var dequeuedItems = new RecyclableLongList<string>();
-			while (list.LongCount > 0)
-			{
-				dequeuedItems.Add(list.Pop());
-			}
+                        var dequeuedItems = new RecyclableLongList<string>();
+                        while (list.LongCount > 0)
+                        {
+                                dequeuedItems.Add(list.Pop());
+                        }
 
-			// Validate
-			_ = dequeuedItems.Should().ContainInConsecutiveOrder(_testData.Reverse());
-		}
+                        // Validate
+                        _ = dequeuedItems.Should().ContainInConsecutiveOrder(data.Reverse());
+                }
 
-		[Fact]
-		public void PopShoudRaiseArgumentOutOfRangeWhenNoMoreElementsFound()
-		{
-			// Prepare
-			using var list = new RecyclableQueue<string>(_testData);
+                [Fact]
+                public void PopShouldRaiseArgumentOutOfRangeWhenNoMoreElementsFound()
+                {
+                        // Prepare
+                        using var list = new RecyclableStack<string>(_testData);
 
-			// Act
-			while (list.LongCount > 0)
-			{
-				_ = list.Dequeue();
-			}
+                        // Act
+                        while (list.LongCount > 0)
+                        {
+                                _ = list.Pop();
+                        }
 
-			_ = Assert.Throws<ArgumentOutOfRangeException>(() => list.Dequeue());
-		}
+                        _ = Assert.Throws<ArgumentOutOfRangeException>(() => list.Pop());
+                }
 	}
 }


### PR DESCRIPTION
## Summary
- expanded new generic collection tests with dataset coverage
- fix PopShouldRaiseArgumentOutOfRangeWhenNoMoreElementsFound to use RecyclableStack

## Testing
- `dotnet test --framework net8.0`

------
https://chatgpt.com/codex/tasks/task_e_6874e2e534c883259a982d79f81452ce