### PR TITLE
Add optimized AddRange overloads

### DIFF
--- a/Recyclable.Collections/RecyclableList.AddRange.cs
+++ b/Recyclable.Collections/RecyclableList.AddRange.cs
@@ -577,10 +577,24 @@ namespace Recyclable.Collections
                         {
                                 AddRange(list, sourceQueue);
                         }
+                        else if (typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(KeyValuePair<,>)
+                                 && items.GetType().IsGenericType && items.GetType().GetGenericTypeDefinition() == typeof(RecyclableDictionary<,>))
+                        {
+                                dynamic dynList = list;
+                                dynamic dynDict = items;
+                                AddRange(dynList, dynDict);
+                        }
+                        else if (typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(ValueTuple<,>)
+                                 && items.GetType().IsGenericType && items.GetType().GetGenericTypeDefinition() == typeof(RecyclableSortedList<,>))
+                        {
+                                dynamic dynList = list;
+                                dynamic dynSortedList = items;
+                                AddRange(dynList, dynSortedList);
+                        }
                         else if (items is IReadOnlyList<T> sourceIReadOnlyList)
-			{
-				AddRange(list, sourceIReadOnlyList);
-			}
+                        {
+                                AddRange(list, sourceIReadOnlyList);
+                        }
 			else if (items.TryGetNonEnumeratedCount(out var requiredAdditionalCapacity) && requiredAdditionalCapacity != 0)
 			{
 				AddRangeWithKnownCount(list, items, list._count, requiredAdditionalCapacity);

--- a/Recyclable.Collections/RecyclableLongList.AddRange.cs
+++ b/Recyclable.Collections/RecyclableLongList.AddRange.cs
@@ -438,10 +438,24 @@ namespace Recyclable.Collections
                                         targetList.AddRange(sourceQueue);
                                         return;
 
-				default:
-					if (items.TryGetNonEnumeratedCount(out var requiredAdditionalCapacity))
-					{
-						targetList.AddRangeWithKnownCount(items, requiredAdditionalCapacity);
+                                case var _ when typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(KeyValuePair<,>)
+                                            && items.GetType().IsGenericType && items.GetType().GetGenericTypeDefinition() == typeof(RecyclableDictionary<,>):
+                                        dynamic dynTargetList = targetList;
+                                        dynamic dynDict = items;
+                                        AddRange(dynTargetList, dynDict);
+                                        return;
+
+                                case var _ when typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(ValueTuple<,>)
+                                            && items.GetType().IsGenericType && items.GetType().GetGenericTypeDefinition() == typeof(RecyclableSortedList<,>):
+                                        dynamic dynTargetList2 = targetList;
+                                        dynamic dynSortedList = items;
+                                        AddRange(dynTargetList2, dynSortedList);
+                                        return;
+
+                                default:
+                                        if (items.TryGetNonEnumeratedCount(out var requiredAdditionalCapacity))
+                                        {
+                                                targetList.AddRangeWithKnownCount(items, requiredAdditionalCapacity);
 					}
 					else
 					{


### PR DESCRIPTION
## Summary
- optimize `AddRange(IEnumerable<T>)` to detect `RecyclableDictionary` and `RecyclableSortedList`
- same logic for `RecyclableLongList`

## Testing
- `dotnet test --framework net8.0 --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_687528d91bb883259072651db0dccc07